### PR TITLE
tree: add storage slot insertions test vector

### DIFF
--- a/tree/004_storageslot_insert.json
+++ b/tree/004_storageslot_insert.json
@@ -1,0 +1,19 @@
+{
+    "name": "Insert EOA",
+    "description": "In an empty tree, do many storage-slot writes for a contract and check the resulting root hash",
+    "testData": {
+        "scAddress": "0x3b7c4c2b2b25239e58f8e67509b32edb5bbf293c",
+        "storageSlots": [
+            0,
+            1,
+            31,
+            32,
+            63,
+            64,
+            100,
+            1000,
+            10001
+        ],
+        "expectedRootHash": "0x5f9b9b718f3658151bdc58e594a951787d0307467b13ea4d1cda411428216a1e"
+    }
+}


### PR DESCRIPTION
This PR adds a new test vector to test storage slot insertions. It writes to an arbitrary contract address the `elephant` value in many storage slots:
- [0, 1, 31, 32, 63], which are a special case in the account header leaf.
- [64, 100, 1000, 10001] which live in different leaf nodes

Holding this PR on draft until we get at least one green signal from another client.

